### PR TITLE
Add specialized copy method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 BinaryProvider = "~0.5"
 CEnum = "0.3"
 GLPK_jll = "~4.64.0"
-MathOptInterface = "~0.9.5"
+MathOptInterface = "~0.9.15"
 julia = "1"
 
 [extras]

--- a/perf/runbench.jl
+++ b/perf/runbench.jl
@@ -3,6 +3,7 @@ using LinearAlgebra
 using Random
 using GLPK
 using MathOptInterface
+# using ProfileView
 const MOI = MathOptInterface
 
 using TimerOutputs
@@ -110,7 +111,7 @@ function time_build_and_solve(to_build, to_solve, At, b, c, scalar = true)
     if to_build !== to_solve
         @timeit "copy" MOI.copy_to(to_solve, to_build, copy_names = false)
     end
-    MOI.set(to_solve, MOI.TimeLimitSec(), 0.10)
+    MOI.set(to_solve, MOI.TimeLimitSec(), 0.0010)
     @time @timeit "opt" MOI.optimize!(to_solve)
     val = MOI.get(to_solve, MOI.SolveTime())
     println(val)
@@ -122,22 +123,26 @@ function solve_GLPK(seed, data; time_limit_sec=Inf)
 
     reset_timer!()
 
+    @timeit "data"  At, b, c = random_data(1, data)
     for i in 1:seed
-
-        @timeit "data"  At, b, c = random_data(i, data)
-
+        # mod(i,5) == 0 && GC.gc()
+        GC.gc()
         bridged_cache, pure_solver = bridged_cache_and_solver()
         @timeit "bc + s" time_build_and_solve(bridged_cache, pure_solver, At, b, c)
-
+        
+        GC.gc()
         cache, pure_solver2 = cache_and_solver()
         @timeit "c + s" time_build_and_solve(cache, pure_solver2, At, b, c)
-
+        
+        GC.gc()
         full_solver = bridged_cached_solver()
         @timeit "bcs" time_build_and_solve(full_solver, full_solver, At, b, c)
-
+        
+        GC.gc()
         full_solver = bridged_cached_solver()
         @timeit "bcs + v" time_build_and_solve(full_solver, full_solver, At, b, c, false)
-
+        
+        GC.gc()
         cache_solver = cached_solver()
         @timeit "cs" time_build_and_solve(cache_solver, cache_solver, At, b, c)
 
@@ -147,4 +152,5 @@ function solve_GLPK(seed, data; time_limit_sec=Inf)
 
 end
 
-solve_GLPK(100, RandomLP(10000, 10000, 0.005); time_limit_sec=5)
+solve_GLPK(2, RandomLP(11, 11, 0.5); time_limit_sec=5)
+solve_GLPK(20, RandomLP(10000, 10000, 0.005); time_limit_sec=5)

--- a/perf/runbench.jl
+++ b/perf/runbench.jl
@@ -1,0 +1,150 @@
+using SparseArrays
+using LinearAlgebra
+using Random
+using GLPK
+using MathOptInterface
+const MOI = MathOptInterface
+
+using TimerOutputs
+
+struct RandomLP
+    rows::Int
+    cols::Int
+    dens::Float64
+end
+
+function generate_moi_problem(model, At, b, c;
+    var_bounds = true, scalar = true)
+    cols, rows = size(At)
+    x = MOI.add_variables(model, cols)
+    A_cols = rowvals(At)
+    A_vals = nonzeros(At)
+    if var_bounds
+        for col in 1:cols
+            MOI.add_constraint(model, MOI.SingleVariable(x[col]),
+                MOI.LessThan(10.0))
+            MOI.add_constraint(model, MOI.SingleVariable(x[col]),
+                MOI.GreaterThan(-10.0))
+        end
+    end
+    if scalar
+        for row in 1:rows
+            MOI.add_constraint(model, MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(A_vals[i], x[A_cols[i]]) for i in nzrange(At, row)], 0.0),
+                MOI.LessThan(b[row]))
+        end
+    else
+        for row in 1:rows
+            MOI.add_constraint(model, MOI.VectorAffineFunction(
+                [MOI.VectorAffineTerm(1, 
+                    MOI.ScalarAffineTerm(A_vals[i], x[A_cols[i]])
+                ) for i in nzrange(At, row)], [-b[row]]),
+                MOI.Nonpositives(1))
+        end
+    end
+    objective = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(c[i], x[i]) for i in findall(!iszero, c)],
+            0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objective)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    return x
+end
+
+function random_data(seed, data)
+
+    rows = data.rows
+    cols = data.cols
+    density = data.dens
+
+    p_neg_element = 0.0 # 0.25
+
+    rng = Random.MersenneTwister(seed)
+
+    f_A(r, n) = ifelse.(rand(r, n) .> p_neg_element, 1, -1) .* (15 .+ 30 .* rand(r, n))
+
+    At = sprand(rng, cols, rows, density, f_A)
+    b = 50 * rand(rng, rows)
+
+    # not using signs now
+    sign = ifelse.(rand(rng, rows) .> 0.2, 'L', 'G')
+
+    f_c(r, n) = 20 .* 2 .* (rand(r, n) .- 0.5)
+    c = sprand(rng, cols, 0.5, f_c)
+
+    return At, b, c
+end
+
+function bridged_cache_and_solver()
+    model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        MOI.Utilities.MANUAL), Float64)
+    GLPK_ = GLPK.Optimizer()
+    MOI.set(GLPK_, MOI.Silent(), true)
+    return model, GLPK_
+end
+function cache_and_solver()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        MOI.Utilities.MANUAL)
+    GLPK_ = GLPK.Optimizer()
+    MOI.set(GLPK_, MOI.Silent(), true)
+    return model, GLPK_
+end
+function bridged_cached_solver()
+    model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        GLPK.Optimizer()), Float64)
+    MOI.set(model, MOI.Silent(), true)
+    return model
+end
+function cached_solver()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        GLPK.Optimizer())
+    MOI.set(model, MOI.Silent(), true)
+    return model
+end
+
+function time_build_and_solve(to_build, to_solve, At, b, c, scalar = true)
+    @timeit "build" x = generate_moi_problem(to_build, At, b, c, scalar = scalar)
+    if to_build !== to_solve
+        @timeit "copy" MOI.copy_to(to_solve, to_build, copy_names = false)
+    end
+    MOI.set(to_solve, MOI.TimeLimitSec(), 0.10)
+    @time @timeit "opt" MOI.optimize!(to_solve)
+    val = MOI.get(to_solve, MOI.SolveTime())
+    println(val)
+    @show MOI.get(to_solve, MOI.ObjectiveValue())
+    @show MOI.get(to_solve, MOI.TerminationStatus())
+end
+
+function solve_GLPK(seed, data; time_limit_sec=Inf)
+
+    reset_timer!()
+
+    for i in 1:seed
+
+        @timeit "data"  At, b, c = random_data(i, data)
+
+        bridged_cache, pure_solver = bridged_cache_and_solver()
+        @timeit "bc + s" time_build_and_solve(bridged_cache, pure_solver, At, b, c)
+
+        cache, pure_solver2 = cache_and_solver()
+        @timeit "c + s" time_build_and_solve(cache, pure_solver2, At, b, c)
+
+        full_solver = bridged_cached_solver()
+        @timeit "bcs" time_build_and_solve(full_solver, full_solver, At, b, c)
+
+        full_solver = bridged_cached_solver()
+        @timeit "bcs + v" time_build_and_solve(full_solver, full_solver, At, b, c, false)
+
+        cache_solver = cached_solver()
+        @timeit "cs" time_build_and_solve(cache_solver, cache_solver, At, b, c)
+
+    end
+
+    print_timer()
+
+end
+
+solve_GLPK(100, RandomLP(10000, 10000, 0.005); time_limit_sec=5)

--- a/src/GLPK.jl
+++ b/src/GLPK.jl
@@ -43,6 +43,7 @@ if !(v"4.64.0" <= _GLPK_VERSION <= v"4.64.0")
 end
 
 include("MOI_wrapper/MOI_wrapper.jl")
+include("MOI_wrapper/MOI_copy.jl")
 include("MOI_wrapper/MOI_callbacks.jl")
 include("MOI_wrapper/deprecated_constants.jl")
 

--- a/src/MOI_wrapper/MOI_copy.jl
+++ b/src/MOI_wrapper/MOI_copy.jl
@@ -4,66 +4,6 @@
 
 const DoubleDicts = MathOptInterface.Utilities.DoubleDicts
 
-struct ContiguousIndex
-    index_map
-end
-# mutable struct DoubleDict
-#     dict::Dict{Tuple{DataType,DataType}, Dict{Int,Int}}
-#     DoubleDict() = new(Dict{Tuple{DataType,DataType}, Dict{Int,Int}}())
-# end
-# mutable struct IndexMap2
-#     varmap::Dict{MOI.VariableIndex, MOI.VariableIndex}
-#     conmap::DoubleDict
-#     IndexMap2() = new(Dict{MOI.VariableIndex, MOI.VariableIndex}(), DoubleDict())
-# end
-
-# Base.sizehint!(d::DoubleDict, n) = nothing#error("Not possible to use sizehint")
-# function Base.sizehint!(d::DoubleDict, ::Type{F}, ::Type{S}, n) where {F,S}
-#     inner = lazy_get(d, F, S)::Dict{Int,Int}
-#     sizehint!(inner, n)
-# end
-# const CI{F,S} = MOI.ConstraintIndex{F,S}
-# function Base.length(d::DoubleDict)
-#     len = 0
-#     for inner in d.dict
-#         len += length(inner)
-#     end
-#     return len
-# end
-# function Base.haskey(dict::DoubleDict, key::CI{F,S}) where {F,S}
-#     inner = get(dict.dict, (F,S), nothing)
-#     if inner !== nothing
-#         inner = dict.dict[(F,S)]
-#         return haskey(inner, key.value)
-#     else
-#         return false
-#     end
-# end
-# function Base.getindex(dict::DoubleDict, key::CI{F,S}) where {F,S}
-#     inner = dict.dict[(F,S)]
-#     k_value = key.value::Int
-#     return CI{F,S}(inner[k_value])
-# end
-# function lazy_get(dict::DoubleDict, ::Type{F}, ::Type{S}) where {F,S}
-#     inner = get(dict.dict, (F,S), nothing) ::Union{Nothing, Dict{Int,Int}}
-#     if inner === nothing
-#         return dict.dict[(F,S)] = Dict{Int,Int}()
-#     end
-#     return inner
-# end
-# function Base.setindex!(dict::DoubleDict, value::CI{F,S}, key::CI{F,S}) where {F,S}
-#     v_value = value.value::Int
-#     k_value = key.value::Int
-#     inner = lazy_get(dict, F, S)::Dict{Int,Int}
-#     inner[k_value] = v_value
-#     return dict
-# end
-# function Base.setindex!(dict::DoubleDict, ::Type{F}, ::Type{S}, value::Int, key::Int) where {F,S}
-#     inner = lazy_get(dict, F, S)::Dict{Int,Int}
-#     inner[key] = value
-#     return dict
-# end
-
 _add_bounds(::Vector{Float64}, ub, i, s::MOI.LessThan{Float64}) = ub[i] = s.upper
 _add_bounds(lb, ::Vector{Float64}, i, s::MOI.GreaterThan{Float64}) = lb[i] = s.lower
 _add_bounds(lb, ub, i, s::MOI.EqualTo{Float64}) = lb[i], ub[i] = s.value, s.value
@@ -73,21 +13,15 @@ _bound_type(::Type{MOI.Interval{Float64}}) = INTERVAL
 _bound_type(::Type{MOI.EqualTo{Float64}}) = EQUAL_TO
 _bound_type(::Type{S}) where S = NONE
 
-get_var(mapping, variable) = mapping.varmap[variable].value
-get_var(mapping::ContiguousIndex, variable) = variable.value
-get_conmap(map) = map.conmap
-get_conmap(map::ContiguousIndex) = map.index_map.conmap
-
-function _extract_bound_data(src, _mapping, lb, ub, bound_type, s::Type{S}) where S
-    dict = DoubleDicts.with_type(get_conmap(_mapping), MOI.SingleVariable, S)
+function _extract_bound_data(src, mapping, lb, ub, bound_type, s::Type{S}) where S
+    dict = DoubleDicts.with_type(mapping.conmap, MOI.SingleVariable, S)
     type = _bound_type(s)
     list = MOI.get(src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}())
     add_sizehint!(dict, length(list))
     for con_index in list
         f = MOI.get(src, MOI.ConstraintFunction(), con_index)
         s = MOI.get(src, MOI.ConstraintSet(), con_index)
-        # column = mapping.varmap[f.variable].value
-        column = get_var(_mapping, f.variable)
+        column = mapping[f.variable].value
         _add_bounds(lb, ub, column, s)
         bound_type[column] = type
         dict[con_index] = MOI.ConstraintIndex{MOI.SingleVariable, S}(column)
@@ -97,46 +31,40 @@ end
 _add_type(type, i, ::MOI.Integer) = type[i] = INTEGER
 _add_type(type, i, ::MOI.ZeroOne) = type[i] = BINARY
 
-function _extract_type_data(src, _mapping, var_type, ::Type{S}) where S
-    dict = DoubleDicts.with_type(get_conmap(_mapping), MOI.SingleVariable, S)
+function _extract_type_data(src, mapping, var_type, ::Type{S}) where S
+    dict = DoubleDicts.with_type(mapping.conmap, MOI.SingleVariable, S)
     list = MOI.get(src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}())
     add_sizehint!(dict, length(list))
     for con_index in list
         f = MOI.get(src, MOI.ConstraintFunction(), con_index)
-        # column = mapping.varmap[f.variable].value
-        column = get_var(_mapping, f.variable)
+        column = mapping[f.variable].value
         _add_type(var_type, column, S())
         dict[con_index] = MOI.ConstraintIndex{MOI.SingleVariable, S}(column)
     end
 end
 
-function _copy_to_columns(dest, src, mapping)
+function _init_index_map(src)
     x_src = MOI.get(src, MOI.ListOfVariableIndices())
     N = Cint(length(x_src))
 
     is_contiguous = true
+    # assuming all indexes are different
     for x in x_src
         if !(1 <= x.value <= N)
             is_contiguous = false
         end
     end
 
+    mapping = if is_contiguous
+        MOIU.IndexMap(N)
+    else
+        MOIU.IndexMap()
+    end
     for i = 1:N
-        # mapping.varmap[x_src[i]] = MOI.VariableIndex(i)
-        mapping.varmap[MOI.VariableIndex(i)] = MOI.VariableIndex(i)
+        mapping[x_src[i]] = MOI.VariableIndex(i)
     end
 
-    # passing objective as attribute
-    # fobj = MOI.get(src, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
-    # c = fill(0.0, N)
-    # for term in fobj.terms
-    #     i = mapping.varmap[term.variable_index].value
-    #     c[i] += term.coefficient
-    # end
-
-    # # pass objective constant
-    # glp_set_obj_coef(dest, 0, fobj.constant)
-    return N, is_contiguous#, c
+    return N, mapping
 end
 
 _bounds2(s::MOI.GreaterThan{Float64}) = (s.lower, Inf)
@@ -149,61 +77,54 @@ function add_sizehint!(vec, n)
     return sizehint!(vec, len + n)
 end
 
-function _extract_row_data(src, _mapping, lb, ub, I, J, V, ::Type{S}) where S
-    dict = DoubleDicts.with_type(get_conmap(_mapping), MOI.ScalarAffineFunction{Float64}, S)
+function _extract_row_data(src, mapping, lb, ub, I, J, V, ::Type{S}) where S
+    dict = mapping.conmap[MOI.ScalarAffineFunction{Float64}, S]
 
-    row = length(I) == 0 ? 1 : I[end] + 1
     list = MOI.get(
         src, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}()
-    )
-    add_sizehint!(lb, length(list))
-    add_sizehint!(ub, length(list))
-    sizehint!(dict, length(list)+length(list))
+    )::Vector{MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}}
 
+    N = length(list)
+    add_sizehint!(lb, N)
+    add_sizehint!(ub, N)
+    add_sizehint!(dict, N)
+
+    # first loop caches functions and counts terms to be added
     n_terms = 0
-    fs = Array{MOI.ScalarAffineFunction{Float64}}(undef, length(list))
-    for (i,c_index) in enumerate(list)
-        # f = MOIU.canonical(MOI.get(src, MOI.ConstraintFunction(), c_index))
-        # MOIU.canonicalize!(MOI.get(src, MOI.ConstraintFunction(), c_index))
-        pre_f = MOI.get(src, MOI.ConstraintFunction(), c_index)
-        f = if MOIU.is_canonical(pre_f)
-            pre_f
+    function_cache = Array{MOI.ScalarAffineFunction{Float64}}(undef, N)
+    for i in 1:N
+        pre_function = MOI.get(src, MOI.ConstraintFunction(), list[i])
+        f = if MOIU.is_canonical(pre_function)
+            pre_function
         else
-            MOIU.canonical(pre_f)
+            # no duplicates are allowed in GLPK
+            MOIU.canonical(pre_function)
         end
-        # f = MOI.get(src, MOI.ConstraintFunction(), c_index)
-        fs[i] = f
-        l, u = _bounds2(MOI.get(src, MOI.ConstraintSet(), c_index))
+        function_cache[i] = f
+        l, u = _bounds2(MOI.get(src, MOI.ConstraintSet(), list[i]))
         push!(lb, l - f.constant)
         push!(ub, u - f.constant)
         n_terms += length(f.terms)
     end
-    # add_sizehint!(I, n_terms)
-    # add_sizehint!(J, n_terms)
-    # add_sizehint!(V, n_terms)
-    c = length(I)
-    resize!(I, c + n_terms)
-    resize!(J, c + n_terms)
-    resize!(V, c + n_terms)
-    for (i,c_index) in enumerate(list)
-        f = fs[i]#MOI.get(src, MOI.ConstraintFunction(), c_index)
+
+    non_zeros = length(I)
+    row = non_zeros == 0 ? 1 : I[end] + 1
+    # resize + setindex is faster than sizehint! + push
+    # makes difference because I, J, V can be huge
+    resize!(I, non_zeros + n_terms)
+    resize!(J, non_zeros + n_terms)
+    resize!(V, non_zeros + n_terms)
+    for i in 1:N
+        f = function_cache[i]
         for term in f.terms
-            c += 1
-            # column = mapping.varmap[f.variable].value
-            column = get_var(_mapping, term.variable_index)
-            # push!(I, Cint(row))
-            # push!(J, Cint(column))
-            # push!(V, term.coefficient)
-            I[c] = row
-            J[c] = column
-            V[c] = term.coefficient
+            non_zeros += 1
+            I[non_zeros] = row
+            J[non_zeros] = Cint(mapping[term.variable_index].value::Int64)
+            V[non_zeros] = term.coefficient
         end
         row += 1
-        dict[c_index] = MOI.ConstraintIndex{
-            MOI.ScalarAffineFunction{Float64}, S
-        }(row)
-        # setindex!(mapping.conmap, MOI.ScalarAffineFunction{Float64}, S,
-        # row, c_index.value)
+        ind = MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, S}(row)
+        dict[list[i]] = ind
     end
     return
 end
@@ -240,7 +161,7 @@ function _add_all_variables(model::Optimizer, N, lower, upper, bound_type,
             model.num_integers += 1
         end
     end
-    return nothing# indices
+    return nothing
 end
 
 function _add_all_constraints(dest::Optimizer, rl, ru, I, J, V)
@@ -248,7 +169,6 @@ function _add_all_constraints(dest::Optimizer, rl, ru, I, J, V)
     n_constraints = length(rl)
 
     glp_add_rows(dest, n_constraints)
-    # @show I, J, V
     glp_load_matrix(dest, length(I), offset(I), offset(J), offset(V))
 
     sizehint!(dest.affine_constraint_info, n_constraints)
@@ -282,14 +202,7 @@ function MOI.copy_to(
     @assert MOI.is_empty(dest)
     test_data(src, dest)
 
-    _mapping = MOI.Utilities.IndexMap()
-    # _mapping = IndexMap2()
-    N, is_contiguous = _copy_to_columns(dest, src, _mapping) # not getting obj
-    mapping = if is_contiguous
-        ContiguousIndex(_mapping)
-    else
-        _mapping
-    end::Union{MOIU.IndexMap, ContiguousIndex}
+    N, mapping = _init_index_map(src)
     cl, cu = fill(-Inf, N), fill(Inf, N)
     bound_type = fill(NONE, N)
     var_type = fill(CONTINUOUS, N)
@@ -306,7 +219,6 @@ function MOI.copy_to(
 
     rl, ru, I, J, V = Float64[], Float64[], Cint[], Cint[], Float64[]
 
-    # add canonical
     _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.GreaterThan{Float64})
     _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.LessThan{Float64})
     _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.EqualTo{Float64})
@@ -315,17 +227,13 @@ function MOI.copy_to(
 
     _add_all_constraints(dest, rl, ru, I, J, V)
 
-    # model attribute
-    # sense = MOI.get(src, MOI.ObjectiveSense())
-    # MOI.set(dest, MOI.ObjectiveSense(), sense)
-
-    # Copy model attributes
-    # obj function and sense are passet here
-    MOIU.pass_attributes(dest, src, copy_names, _mapping)
+    # Copy model attributes:
+    # obj function and sense are passed here
+    MOIU.pass_attributes(dest, src, copy_names, mapping)
     variables = MOI.get(src, MOI.ListOfVariableIndices())
-    MOIU.pass_attributes(dest, src, copy_names, _mapping, variables)
-    pass_constraint_attributes(dest, src, copy_names, _mapping)
-    return _mapping
+    MOIU.pass_attributes(dest, src, copy_names, mapping, variables)
+    pass_constraint_attributes(dest, src, copy_names, mapping)
+    return mapping
 end
 
 function pass_constraint_attributes(dest, src, copy_names, mapping)

--- a/src/MOI_wrapper/MOI_copy.jl
+++ b/src/MOI_wrapper/MOI_copy.jl
@@ -68,8 +68,8 @@ function _init_index_map(src)
         end
     end
     mapping = is_contiguous ? MOIU.IndexMap(N) : MOIU.IndexMap()
-    for i = 1:N
-        mapping[x_src[i]] = MOI.VariableIndex(i)
+    for (i, x) in enumerate(x_src)
+        mapping[x] = MOI.VariableIndex(i)
     end
     return N, mapping
 end
@@ -202,7 +202,7 @@ function _add_all_constraints(dest::Optimizer, rl, ru, I, J, V)
 end
 
 function MOI.copy_to(
-    dest::Optimizer, src::MOI.ModelLike; copy_names::Bool = false
+    dest::Optimizer, src::MOI.ModelLike; copy_names::Bool = false, kwargs...
 )
     @assert MOI.is_empty(dest)
     test_data(src, dest)
@@ -229,7 +229,8 @@ function MOI.copy_to(
     MOIU.pass_attributes(dest, src, copy_names, mapping)
     variables = MOI.get(src, MOI.ListOfVariableIndices())
     MOIU.pass_attributes(dest, src, copy_names, mapping, variables)
-    pass_constraint_attributes(dest, src, copy_names, mapping)
+    # TODO(odow): fix copy_names = false.
+    pass_constraint_attributes(dest, src, false, mapping)
     return mapping
 end
 

--- a/src/MOI_wrapper/MOI_copy.jl
+++ b/src/MOI_wrapper/MOI_copy.jl
@@ -1,0 +1,229 @@
+# =======================
+#   `copy_to` function
+# =======================
+
+_add_bounds(::Vector{Float64}, ub, i, s::MOI.LessThan{Float64}) = ub[i] = s.upper
+_add_bounds(lb, ::Vector{Float64}, i, s::MOI.GreaterThan{Float64}) = lb[i] = s.lower
+_add_bounds(lb, ub, i, s::MOI.EqualTo{Float64}) = lb[i], ub[i] = s.value, s.value
+_add_bounds(lb, ub, i, s::MOI.Interval{Float64}) = lb[i], ub[i] = s.lower, s.upper
+
+_bound_type(::Type{MOI.Interval{Float64}}) = INTERVAL
+_bound_type(::Type{MOI.EqualTo{Float64}}) = EQUAL_TO
+_bound_type(::Type{S}) where S = NONE
+
+function _extract_bound_data(src, mapping, lb, ub, bound_type, s::Type{S}) where S
+    type = _bound_type(s)
+    for con_index in MOI.get(
+        src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
+    )
+        f = MOI.get(src, MOI.ConstraintFunction(), con_index)
+        s = MOI.get(src, MOI.ConstraintSet(), con_index)
+        column = mapping.varmap[f.variable].value
+        _add_bounds(lb, ub, column, s)
+        bound_type[column] = type
+        mapping.conmap[con_index] = MOI.ConstraintIndex{MOI.SingleVariable, S}(column)
+    end
+end
+
+_add_type(type, i, ::MOI.Integer) = type[i] = INTEGER
+_add_type(type, i, ::MOI.ZeroOne) = type[i] = BINARY
+
+function _extract_type_data(src, mapping, var_type, ::Type{S}) where S
+    for con_index in MOI.get(
+        src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
+    )
+        f = MOI.get(src, MOI.ConstraintFunction(), con_index)
+        column = mapping.varmap[f.variable].value
+        _add_type(var_type, column, S())
+        mapping.conmap[con_index] = MOI.ConstraintIndex{MOI.SingleVariable, S}(column)
+    end
+end
+
+function _copy_to_columns(dest, src, mapping)
+    x_src = MOI.get(src, MOI.ListOfVariableIndices())
+    N = Cint(length(x_src))
+    for i = 1:N
+        mapping.varmap[x_src[i]] = MOI.VariableIndex(i)
+    end
+
+    # passing objective as attribute
+    # fobj = MOI.get(src, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    # c = fill(0.0, N)
+    # for term in fobj.terms
+    #     i = mapping.varmap[term.variable_index].value
+    #     c[i] += term.coefficient
+    # end
+
+    # # pass objective constant
+    # glp_set_obj_coef(dest, 0, fobj.constant)
+    return N#, c
+end
+
+_bounds2(s::MOI.GreaterThan{Float64}) = (s.lower, Inf)
+_bounds2(s::MOI.LessThan{Float64}) = (-Inf, s.upper)
+_bounds2(s::MOI.EqualTo{Float64}) = (s.value, s.value)
+_bounds2(s::MOI.Interval{Float64}) = (s.lower, s.upper)
+
+function add_sizehint!(vec, n)
+    len = length(vec)
+    return sizehint!(vec, len + n)
+end
+
+function _extract_row_data(src, mapping, lb, ub, I, J, V, ::Type{S}) where S
+    row = length(I) == 0 ? 1 : I[end] + 1
+    list = MOI.get(
+        src, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}()
+    )
+    add_sizehint!(lb, length(list))
+    add_sizehint!(ub, length(list))
+    n_terms = 0
+    fs = Array{MOI.ScalarAffineFunction{Float64}}(undef, length(list))
+    for (i,c_index) in enumerate(list)
+        f = MOIU.canonical(MOI.get(src, MOI.ConstraintFunction(), c_index))
+        fs[i] = f
+        l, u = _bounds2(MOI.get(src, MOI.ConstraintSet(), c_index))
+        push!(lb, l - f.constant)
+        push!(ub, u - f.constant)
+        n_terms += length(f.terms)
+    end
+    add_sizehint!(I, n_terms)
+    add_sizehint!(J, n_terms)
+    add_sizehint!(V, n_terms)
+    for (i,c_index) in enumerate(list)
+        f = fs[i]#MOI.get(src, MOI.ConstraintFunction(), c_index)
+        for term in f.terms
+            push!(I, Cint(row))
+            push!(J, Cint(mapping.varmap[term.variable_index].value))
+            push!(V, term.coefficient)
+        end
+        mapping.conmap[c_index] = MOI.ConstraintIndex{
+            MOI.ScalarAffineFunction{Float64}, S
+        }(length(ub))
+        row += 1
+    end
+    return
+end
+
+function test_data(src, dest)
+    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
+        if !MOI.supports_constraint(dest, F, S)
+            throw(MOI.UnsupportedConstraint{F, S}("GLPK.Optimizer does not support constraints of type $F-in-$S."))
+        end
+    end
+    fobj_type = MOI.get(src, MOI.ObjectiveFunctionType())
+    if !MOI.supports(dest, MOI.ObjectiveFunction{fobj_type}())
+        throw(MOI.UnsupportedAttribute(MOI.ObjectiveFunction(fobj_type)))
+    end
+end
+
+function _add_all_variables(model::Optimizer, N, lower, upper, bound_type,
+    var_type)
+    glp_add_cols(model, N)
+    for i in 1:N
+        bound = get_moi_bound_type(lower[i], upper[i], bound_type)
+        # We started from empty model.variable_info, hence we assume ordering
+        index = CleverDicts.add_item(
+            model.variable_info, VariableInfo(MOI.VariableIndex(i), i, bound, var_type[i])
+        )
+        glp_bound_type = get_glp_bound_type(lower[i], upper[i])
+        glp_set_col_bnds(model, i, glp_bound_type, lower[i], upper[i])
+        if var_type[i] == BINARY
+            model.num_binaries += 1
+        end
+        if var_type[i] == INTEGER
+            model.num_integers += 1
+        end
+    end
+    return nothing# indices
+end
+
+function _add_all_constraints(dest::Optimizer, rl, ru, I, J, V)
+
+    n_constraints = length(rl)
+
+    glp_add_rows(dest, n_constraints)
+    # @show I, J, V
+    glp_load_matrix(dest, length(I), offset(I), offset(J), offset(V))
+    for i in 1:n_constraints
+        # assume ordered indexing
+        if rl[i] == ru[i]
+            glp_set_row_bnds(dest, i, GLP_FX, rl[i], ru[i])
+            CleverDicts.add_item(dest.affine_constraint_info,
+                ConstraintInfo(i, MOI.EqualTo{Float64}(rl[i])))
+        elseif ru[i] == Inf
+            glp_set_row_bnds(dest, i, GLP_LO, rl[i], GLP_DBL_MAX)
+            CleverDicts.add_item(dest.affine_constraint_info,
+                ConstraintInfo(i, MOI.GreaterThan{Float64}(rl[i])))
+        else
+            glp_set_row_bnds(dest, i, GLP_UP, -GLP_DBL_MAX, ru[i])
+            CleverDicts.add_item(dest.affine_constraint_info,
+                ConstraintInfo(i, MOI.LessThan{Float64}(ru[i])))
+        end
+    end
+    return
+end
+
+function MOI.copy_to(
+# function _copy_to(
+    dest::Optimizer,
+    src::MOI.ModelLike;
+    copy_names::Bool = false
+)
+    @assert MOI.is_empty(dest)
+    test_data(src, dest)
+
+    mapping = MOI.Utilities.IndexMap()
+    N = _copy_to_columns(dest, src, mapping) # not getting obj
+    cl, cu = fill(-Inf, N), fill(Inf, N)
+    bound_type = fill(NONE, N)
+    var_type = fill(CONTINUOUS, N)
+
+    _extract_bound_data(src, mapping, cl, cu, bound_type, MOI.GreaterThan{Float64})
+    _extract_bound_data(src, mapping, cl, cu, bound_type, MOI.LessThan{Float64})
+    _extract_bound_data(src, mapping, cl, cu, bound_type, MOI.EqualTo{Float64})
+    _extract_bound_data(src, mapping, cl, cu, bound_type, MOI.Interval{Float64})
+
+    _extract_type_data(src, mapping, var_type, MOI.Integer)
+    _extract_type_data(src, mapping, var_type, MOI.ZeroOne)
+
+    _add_all_variables(dest, N, cl, cu, bound_type, var_type)
+
+    rl, ru, I, J, V = Float64[], Float64[], Cint[], Cint[], Float64[]
+
+    # add canonical
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.GreaterThan{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.LessThan{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.EqualTo{Float64})
+    # range constraints not supported
+    # _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.Interval{Float64})
+
+    _add_all_constraints(dest, rl, ru, I, J, V)
+
+    # model attribute
+    # sense = MOI.get(src, MOI.ObjectiveSense())
+    # MOI.set(dest, MOI.ObjectiveSense(), sense)
+
+    # Copy model attributes
+    # obj function and sense are passet here
+    MOIU.pass_attributes(dest, src, copy_names, mapping)
+
+    variables = MOI.get(src, MOI.ListOfVariableIndices())
+    MOIU.pass_attributes(dest, src, copy_names, mapping, variables)
+
+    pass_constraint_attributes(dest, src, copy_names, mapping)
+    return mapping
+end
+
+function pass_constraint_attributes(dest, src, copy_names, mapping)
+    ctr_types = MOI.get(src, MOI.ListOfConstraints())
+    for (F,S) in ctr_types
+        pass_constraint_attributes(dest, src, copy_names, mapping, F, S)
+    end
+    return
+end
+function pass_constraint_attributes(dest, src, copy_names, mapping,
+    ::Type{F}, ::Type{S}) where {F,S}
+    indices = MOI.get(dest, MOI.ListOfConstraintIndices{F, S}())
+    MOIU.pass_attributes(dest, src, copy_names, mapping, indices)
+    return
+end

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1582,7 +1582,7 @@ function MOI.get(model::Optimizer, attr::MOI.DualStatus)
     (status, _) = _get_status(model)
     if status == MOI.OPTIMAL
         return MOI.FEASIBLE_POINT
-    elseif status == MOI.INFEASIBLE || status == MOI.LOCALLY_INFEASIBLE
+    elseif status == MOI.INFEASIBLE
         if _certificates_potentially_available(model)
             return MOI.INFEASIBILITY_CERTIFICATE
         end

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1,6 +1,7 @@
 import MathOptInterface
 
 const MOI = MathOptInterface
+const MOIU = MOI.Utilities
 const CleverDicts = MOI.Utilities.CleverDicts
 
 @enum(TypeEnum, CONTINUOUS, BINARY, INTEGER)
@@ -26,6 +27,10 @@ mutable struct VariableInfo
     function VariableInfo(index::MOI.VariableIndex, column::Int)
         return new(index, column, NONE, CONTINUOUS, "", "", "", "")
     end
+    function VariableInfo(index::MOI.VariableIndex, column::Int, bound::BoundEnum,
+        type::TypeEnum)
+        return new(index, column, bound, type, "", "", "", "")
+    end
 end
 
 struct ConstraintKey
@@ -39,6 +44,7 @@ mutable struct ConstraintInfo
     set::MOI.AbstractSet
     name::String
     ConstraintInfo(set) = new(0, set, "")
+    ConstraintInfo(row, set) = new(row, set, "")
 end
 
 # Dummy callback function for internal use only. Responsible for updating the
@@ -355,9 +361,9 @@ end
 
 MOI.Utilities.supports_default_copy_to(::Optimizer, ::Bool) = true
 
-function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kwargs...)
-    return MOI.Utilities.automatic_copy_to(dest, src; kwargs...)
-end
+# function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kwargs...)
+#     return MOI.Utilities.automatic_copy_to(dest, src; kwargs...)
+# end
 
 function MOI.get(model::Optimizer, ::MOI.ListOfVariableAttributesSet)
     return MOI.AbstractVariableAttribute[MOI.VariableName()]
@@ -758,6 +764,29 @@ end
 
 const GLP_DBL_MAX = prevfloat(Inf)
 
+function get_glp_bound_type(lower, upper)
+    if lower == upper
+        GLP_FX
+    elseif lower <= -GLP_DBL_MAX
+        upper >= GLP_DBL_MAX ? GLP_FR : GLP_UP
+    else
+        upper >= GLP_DBL_MAX ? GLP_LO : GLP_DB
+    end
+end
+function get_moi_bound_type(lower, upper, type)
+    if type == INTERVAL
+        INTERVAL
+    elseif type == EQUAL_TO
+        EQUAL_TO
+    elseif lower == upper
+        LESS_AND_GREATER_THAN
+    elseif lower <= -GLP_DBL_MAX
+        upper >= GLP_DBL_MAX ? NONE : LESS_THAN
+    else
+        upper >= GLP_DBL_MAX ? GREATER_THAN : LESS_AND_GREATER_THAN
+    end
+end
+
 function _set_variable_bound(
     model::Optimizer,
     column::Int,
@@ -770,18 +799,8 @@ function _set_variable_bound(
     if upper === nothing
         upper = glp_get_col_ub(model, column)
     end
-    bound_type = if lower == upper
-        GLP_FX
-    elseif lower <= -GLP_DBL_MAX
-        upper >= GLP_DBL_MAX ? GLP_FR : GLP_UP
-    else
-        upper >= GLP_DBL_MAX ? GLP_LO : GLP_DB
-    end
-    if upper < lower
-        glp_set_col_bnds(model, column, bound_type, lower, upper)
-    else
-        glp_set_col_bnds(model, column, bound_type, lower, upper)
-    end
+    bound_type = get_glp_bound_type(lower, upper)
+    glp_set_col_bnds(model, column, bound_type, lower, upper)
     return
 end
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -361,10 +361,6 @@ end
 
 MOI.Utilities.supports_default_copy_to(::Optimizer, ::Bool) = true
 
-# function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kwargs...)
-#     return MOI.Utilities.automatic_copy_to(dest, src; kwargs...)
-# end
-
 function MOI.get(model::Optimizer, ::MOI.ListOfVariableAttributesSet)
     return MOI.AbstractVariableAttribute[MOI.VariableName()]
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -8,6 +8,14 @@ const OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
 )
 const CONFIG = MOIT.TestConfig()
 
+const COPY_OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
+    MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        GLPK.Optimizer()
+    ),
+    Float64,
+)
+
 @testset "Unit Tests" begin
     MOIT.basic_constraint_tests(OPTIMIZER, CONFIG)
     MOIT.unittest(OPTIMIZER, CONFIG, [
@@ -42,8 +50,16 @@ const CONFIG = MOIT.TestConfig()
 end
 
 @testset "Linear tests" begin
-@testset "Default Solver"  begin
+    @testset "Default Solver"  begin
         MOIT.contlineartest(OPTIMIZER, MOIT.TestConfig(basis = true), [
+            # This requires an infeasiblity certificate for a variable bound.
+            "linear12",
+            # VariablePrimalStart not supported.
+            "partial_start"
+        ])
+    end
+    @testset "Copy Solver"  begin
+        MOIT.contlineartest(COPY_OPTIMIZER, MOIT.TestConfig(basis = true), [
             # This requires an infeasiblity certificate for a variable bound.
             "linear12",
             # VariablePrimalStart not supported.

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -8,14 +8,6 @@ const OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
 )
 const CONFIG = MOIT.TestConfig()
 
-const COPY_OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
-    MOI.Utilities.CachingOptimizer(
-        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
-        GLPK.Optimizer()
-    ),
-    Float64,
-)
-
 @testset "Unit Tests" begin
     MOIT.basic_constraint_tests(OPTIMIZER, CONFIG)
     MOIT.unittest(OPTIMIZER, CONFIG, [
@@ -52,14 +44,6 @@ end
 @testset "Linear tests" begin
     @testset "Default Solver"  begin
         MOIT.contlineartest(OPTIMIZER, MOIT.TestConfig(basis = true), [
-            # This requires an infeasiblity certificate for a variable bound.
-            "linear12",
-            # VariablePrimalStart not supported.
-            "partial_start"
-        ])
-    end
-    @testset "Copy Solver"  begin
-        MOIT.contlineartest(COPY_OPTIMIZER, MOIT.TestConfig(basis = true), [
             # This requires an infeasiblity certificate for a variable bound.
             "linear12",
             # VariablePrimalStart not supported.
@@ -477,4 +461,27 @@ end
     model = GLPK.Optimizer()
     MOI.set(model, MOI.RawParameter("msg_lev"), GLPK.MSG_OFF)
     @test MOI.get(model, MOI.RawParameter("msg_lev")) == GLPK.GLP_MSG_OFF
+end
+
+@testset "MOI.copy" begin
+    dest = GLPK.Optimizer()
+    src = MOI.Utilities.Model{Float64}()
+    MOI.Utilities.loadfromstring!(src, """
+        variables: a, b, c, d
+        minobjective: a + b + c + d
+        c1: a >= 1.0
+        c2: b <= 2.0
+        c3: c == 3.0
+        c4: d in Interval(-4.0, 4.0)
+        c5: a in Integer()
+        c6: b in ZeroOne()
+        c7: a + b >= -1.1
+        c8: a + b <= 2.2
+        c8: c + d == 2.2
+    """)
+    MOI.copy_to(dest, src; copy_names = true)
+    v = MOI.get(dest, MOI.ListOfVariableIndices())
+    @test length(v) == 4
+    names = MOI.get.(dest, MOI.VariableName(), v)
+    @test names == ["a", "b", "c", "d"]
 end


### PR DESCRIPTION
Following the lines of https://github.com/jump-dev/Clp.jl/pull/94

Add a batch copy, it seems that the batch is not much better than one-by-one for GLPK.

Running the runbench.jl file from the perf folder.

Before this PR we had:
```
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:       143s / 100%            30.4GiB / 100%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 bcs + v      100    32.9s  23.0%   329ms   7.23GiB  23.8%  74.0MiB
   build      100    18.8s  13.1%   188ms   7.22GiB  23.7%  73.9MiB
   opt        100    13.8s  9.66%   138ms   7.64MiB  0.02%  78.2KiB
 cs           100    29.0s  20.3%   290ms   5.28GiB  17.4%  54.1MiB
   build      100    15.0s  10.5%   150ms   5.28GiB  17.3%  54.0MiB
   opt        100    13.7s  9.61%   137ms   7.64MiB  0.02%  78.2KiB
 bc + s       100    27.8s  19.4%   278ms   5.83GiB  19.2%  59.7MiB
   opt        100    13.6s  9.53%   136ms     0.00B  0.00%    0.00B
   copy       100    10.8s  7.52%   108ms   3.81GiB  12.5%  39.1MiB
   build      100    3.12s  2.19%  31.2ms   2.01GiB  6.62%  20.6MiB
 bcs          100    26.5s  18.6%   265ms   5.28GiB  17.4%  54.1MiB
   opt        100    13.8s  9.63%   138ms   7.64MiB  0.02%  78.2KiB
   build      100    12.5s  8.72%   125ms   5.28GiB  17.3%  54.0MiB
 c + s        100    24.8s  17.3%   248ms   5.27GiB  17.3%  53.9MiB
   opt        100    13.6s  9.50%   136ms     0.00B  0.00%    0.00B
   copy       100    9.07s  6.34%  90.7ms   3.25GiB  10.7%  33.3MiB
   build      100    1.88s  1.32%  18.8ms   2.01GiB  6.62%  20.6MiB
 data         100    2.00s  1.40%  20.0ms   1.54GiB  5.06%  15.8MiB
 ──────────────────────────────────────────────────────────────────
```
After:
```
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:       138s / 100%            28.7GiB / 100%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 bcs + v      100    31.0s  22.4%   310ms   7.23GiB  25.2%  74.0MiB
   build      100    16.9s  12.3%   169ms   7.22GiB  25.2%  73.9MiB
   opt        100    13.7s  9.94%   137ms   7.64MiB  0.03%  78.2KiB
 cs           100    30.6s  22.2%   306ms   5.28GiB  18.4%  54.1MiB
   build      100    16.6s  12.0%   166ms   5.28GiB  18.4%  54.0MiB
   opt        100    13.7s  9.91%   137ms   7.64MiB  0.03%  78.2KiB
 bcs          100    26.4s  19.1%   264ms   5.28GiB  18.4%  54.1MiB
   opt        100    13.7s  9.93%   137ms   7.64MiB  0.03%  78.2KiB
   build      100    12.3s  8.94%   123ms   5.28GiB  18.4%  54.0MiB
 bc + s       100    24.8s  18.0%   248ms   4.82GiB  16.8%  49.3MiB
   opt        100    13.1s  9.51%   131ms     0.00B  0.00%    0.00B
   copy       100    9.08s  6.58%  90.8ms   2.80GiB  9.78%  28.7MiB
   build      100    2.34s  1.69%  23.4ms   2.01GiB  7.03%  20.6MiB
 c + s        100    22.7s  16.5%   227ms   4.50GiB  15.7%  46.1MiB
   opt        100    13.1s  9.51%   131ms     0.00B  0.00%    0.00B
   copy       100    7.29s  5.28%  72.9ms   2.49GiB  8.69%  25.5MiB
   build      100    2.07s  1.50%  20.7ms   2.01GiB  7.03%  20.6MiB
 data         100    2.58s  1.87%  25.8ms   1.54GiB  5.37%  15.8MiB
 ──────────────────────────────────────────────────────────────────
```

I haven't used the profiler though, there might be some gains.
Moreover, https://github.com/jump-dev/MathOptInterface.jl/pull/1122 could help here.