### PR TITLE
Fix use of CleverDict for 32-bits

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -34,7 +34,7 @@ mutable struct VariableInfo
 end
 
 struct ConstraintKey
-    value::Int
+    value::Int64
 end
 CleverDicts.key_to_index(k::ConstraintKey) = k.value
 CleverDicts.index_to_key(::Type{ConstraintKey}, index) = ConstraintKey(index)


### PR DESCRIPTION
The MOI wrapper is currently failing on 32 bits due to
https://github.com/jump-dev/MathOptInterface.jl/blob/21fd61cc906662834866b287dc15c628723fee34/src/Utilities/CleverDicts.jl#L169
See https://ci.appveyor.com/project/JuliaPolyhedra/polyhedra-jl/builds/35315395/job/lh2158kp2srcxc8l