### PR TITLE
Cap TimeLimitSec to typemax(Int32)

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -376,13 +376,10 @@ function MOI.get(model::Optimizer, param::MOI.RawParameter)
     throw(MOI.UnsupportedAttribute(param))
 end
 
+_limit_sec_to_ms(::Nothing) = typemax(Int32)
+_limit_sec_to_ms(x::Real) = convert(Int32, min(typemax(Int32), 1_000 * x))
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Union{Nothing,Real})
-    if limit === nothing
-        MOI.set(model, MOI.RawParameter("tm_lim"), typemax(Int32))
-    else
-        limit_ms = ceil(Int32, limit * 1_000)
-        MOI.set(model, MOI.RawParameter("tm_lim"), limit_ms)
-    end
+    MOI.set(model, MOI.RawParameter("tm_lim"), _limit_sec_to_ms(limit))
     return
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -625,3 +625,9 @@ end
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
     @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
 end
+
+@testset "large_time_limits" begin
+    model = GLPK.Optimizer()
+    MOI.set(model, MOI.TimeLimitSec(), 1e9)
+    @test MOI.get(model, MOI.TimeLimitSec()) == typemax(Cint)
+end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -629,5 +629,5 @@ end
 @testset "large_time_limits" begin
     model = GLPK.Optimizer()
     MOI.set(model, MOI.TimeLimitSec(), 1e9)
-    @test MOI.get(model, MOI.TimeLimitSec()) == typemax(Cint)
+    @test MOI.get(model, MOI.TimeLimitSec()) == typemax(Cint) / 1_000
 end


### PR DESCRIPTION
Avoids a truncation error then Julia attempts to cast a value that exceeds the typemax to a Cint.

Closes #167 