### PR TITLE
Handle fractional number of ms in TimeLimitSec

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -377,7 +377,7 @@ function MOI.get(model::Optimizer, param::MOI.RawParameter)
 end
 
 _limit_sec_to_ms(::Nothing) = typemax(Int32)
-_limit_sec_to_ms(x::Real) = convert(Int32, min(typemax(Int32), 1_000 * x))
+_limit_sec_to_ms(x::Real) = ceil(Int32, min(typemax(Int32), 1_000 * x))
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Union{Nothing,Real})
     MOI.set(model, MOI.RawParameter("tm_lim"), _limit_sec_to_ms(limit))
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -631,3 +631,9 @@ end
     MOI.set(model, MOI.TimeLimitSec(), 1e9)
     @test MOI.get(model, MOI.TimeLimitSec()) == typemax(Cint) / 1_000
 end
+
+@testset "fractional_time_limits" begin
+    model = GLPK.Optimizer()
+    MOI.set(model, MOI.TimeLimitSec(), 1.2345)
+    @test MOI.get(model, MOI.TimeLimitSec()) == 1.235
+end


### PR DESCRIPTION
Previous code assumed someone would pass a "nice" time limit that was an integer number of milliseconds, not something like `1.234567` seconds.