### PR TITLE
Update deprecated_constants.jl

### DIFF
--- a/src/MOI_wrapper/deprecated_constants.jl
+++ b/src/MOI_wrapper/deprecated_constants.jl
@@ -18,7 +18,7 @@ function MOI.set(
         "The GLPK constants have been renamed from `GLPK.XXX` to " *
         "`GLPK.GLP_XXX` in order to better match the C API. For example, " *
         "`GLPK.MSG_OFF` is now `GLPK.GLP_MSG_OFF`. Support for the old " *
-        "constants will be removed in a future release."
+        "constants will be removed in a future release.", maxlog=1
     )
     MOI.set(model, param, value.x)
 end


### PR DESCRIPTION
Running the Convex.jl tests spams like 100+ of these messages. Setting `maxlog=1` should help by having it only print once. An alternative would be to use `Base.depwarn` to make it an actual deprecation warning which will only show up in tests or if you start julia with `--depwarn=yes` (on Julia 1.5+; it shows by default on earlier versions, I think), and only print once.