### PR TITLE
More fixes to copy_to

### DIFF
--- a/src/MOI_wrapper/MOI_copy.jl
+++ b/src/MOI_wrapper/MOI_copy.jl
@@ -145,8 +145,10 @@ function _add_all_variables(model::Optimizer, cache::_OptimizerCache)
         glp_set_col_bnds(model, i, glp_bound_type, cache.cl[i], cache.cu[i])
         if cache.types[i] == BINARY
             model.num_binaries += 1
+            glp_set_col_kind(model, i, GLP_IV)
         elseif cache.types[i] == INTEGER
             model.num_integers += 1
+            glp_set_col_kind(model, i, GLP_IV)
         end
     end
     return
@@ -154,6 +156,9 @@ end
 
 function _add_all_constraints(dest::Optimizer, cache::_OptimizerCache)
     N = length(cache.rl)
+    if N == 0
+        return  # GLPK doesn't like it if we add 0 rows...
+    end
     glp_add_rows(dest, N)
     glp_load_matrix(
         dest,

--- a/test/MOI_callbacks.jl
+++ b/test/MOI_callbacks.jl
@@ -25,9 +25,7 @@ end
 function _callback_simple_model(cache)
     model = if cache
         m = MOI.Utilities.CachingOptimizer(
-            MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{Float64}(),
-            ),
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
             GLPK.Optimizer(),
         )
         MOI.Utilities.reset_optimizer(m)
@@ -55,9 +53,7 @@ end
 function _callback_knapsack_model(cache)
     model = if cache
         m = MOI.Utilities.CachingOptimizer(
-            MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{Float64}(),
-            ),
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
             GLPK.Optimizer(),
         )
         MOI.Utilities.reset_optimizer(m)
@@ -93,19 +89,10 @@ function test_lazy_constraint(cache)
         MOI.LazyConstraintCallback(),
         (cb_data) -> begin
             lazy_called = true
-            x_val = MOI.get(
-                model,
-                MOI.CallbackVariablePrimal(cb_data),
-                x,
-            )
-            y_val = MOI.get(
-                model,
-                MOI.CallbackVariablePrimal(cb_data),
-                y,
-            )
+            x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+            y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
             @test MOI.supports(model, MOI.LazyConstraint(cb_data))
-            status =
-                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
             if [x_val, y_val] ≈ round.(Int, [x_val, y_val])
                 atol = 1e-7
                 @test status == MOI.CALLBACK_NODE_STATUS_INTEGER
@@ -162,7 +149,7 @@ function test_lazy_constraint_optimize_in_progress(cache)
             )
         end,
     )
-    MOI.optimize!(model)
+    return MOI.optimize!(model)
 end
 
 function test_no_cache_LazyConstraint_UserCut()
@@ -174,10 +161,7 @@ function test_no_cache_LazyConstraint_UserCut()
             MOI.submit(
                 model,
                 MOI.UserCut(cb_data),
-                MOI.ScalarAffineFunction(
-                    [MOI.ScalarAffineTerm(1.0, x)],
-                    0.0,
-                ),
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
                 MOI.LessThan(2.0),
             )
         end,
@@ -197,12 +181,7 @@ function test_no_cache_LazyConstraint_HeuristicSolution()
         model,
         MOI.LazyConstraintCallback(),
         (cb_data) -> begin
-            MOI.submit(
-                model,
-                MOI.HeuristicSolution(cb_data),
-                [x, y],
-                [1.0, 2.0],
-            )
+            MOI.submit(model, MOI.HeuristicSolution(cb_data), [x, y], [1.0, 2.0])
         end,
     )
     @test_throws(
@@ -230,8 +209,7 @@ function test_UserCut(cache)
                 end
             end
             @test MOI.supports(model, MOI.UserCut(cb_data))
-            status =
-                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
             @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
             if accumulated > 10.0
                 MOI.submit(
@@ -258,10 +236,7 @@ function test_no_cache_UserCut_LazyConstraint()
             MOI.submit(
                 model,
                 MOI.LazyConstraint(cb_data),
-                MOI.ScalarAffineFunction(
-                    MOI.ScalarAffineTerm.(1.0, x),
-                    0.0,
-                ),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
                 MOI.LessThan(5.0),
             )
         end,
@@ -306,8 +281,7 @@ function test_Heuristic(cache)
         model,
         MOI.HeuristicCallback(),
         (cb_data) -> begin
-            x_vals =
-                MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+            x_vals = MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
             @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
             if MOI.submit(
                 model,
@@ -325,8 +299,7 @@ function test_Heuristic(cache)
             ) == MOI.HEURISTIC_SOLUTION_REJECTED
                 solution_rejected = true
             end
-            status =
-                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
             @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
         end,
     )
@@ -345,10 +318,7 @@ function test_no_cache_Heuristic_LazyConstraint()
             MOI.submit(
                 model,
                 MOI.LazyConstraint(cb_data),
-                MOI.ScalarAffineFunction(
-                    MOI.ScalarAffineTerm.(1.0, x),
-                    0.0,
-                ),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
                 MOI.LessThan(5.0),
             )
         end,
@@ -371,10 +341,7 @@ function test_no_cache_Heuristic_UserCut()
             MOI.submit(
                 model,
                 MOI.UserCut(cb_data),
-                MOI.ScalarAffineFunction(
-                    MOI.ScalarAffineTerm.(1.0, x),
-                    0.0,
-                ),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
                 MOI.LessThan(5.0),
             )
         end,
@@ -409,7 +376,7 @@ function test_CallbackFunction_OptimizeInProgress(cache)
         end,
     )
     @test MOI.supports(model, GLPK.CallbackFunction())
-    MOI.optimize!(model)
+    return MOI.optimize!(model)
 end
 
 function test_CallbackFunction_LazyConstraint(cache)
@@ -475,8 +442,7 @@ function test_CallbackFunction_UserCut(cache)
             reason = GLPK.glp_ios_reason(cb_data.tree)
             push!(cb_calls, reason)
             if reason != GLPK.GLP_ICUTGEN
-                status =
-                    MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+                status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
                 @test status !== nothing
                 return
             end
@@ -497,8 +463,7 @@ function test_CallbackFunction_UserCut(cache)
                 )
                 user_cut_submitted = true
             end
-            status =
-                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
             @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
         end,
     )
@@ -539,8 +504,7 @@ function test_CallbackFunction_HeuristicSolution(cache)
             ) == MOI.HEURISTIC_SOLUTION_REJECTED
                 solution_rejected = true
             end
-            status =
-                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
             @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
         end,
     )

--- a/test/MOI_callbacks.jl
+++ b/test/MOI_callbacks.jl
@@ -1,9 +1,41 @@
+module TestCallbacks
+
 using GLPK, Test, Random
 
 const MOI = GLPK.MOI
 
-function callback_simple_model()
-    model = GLPK.Optimizer()
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if !startswith("$(name)", "test_")
+            continue
+        elseif startswith("$(name)", "test_no_cache_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        else
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)(true)
+                getfield(@__MODULE__, name)(false)
+            end
+        end
+    end
+    return
+end
+
+function _callback_simple_model(cache)
+    model = if cache
+        m = MOI.Utilities.CachingOptimizer(
+            MOI.Utilities.UniversalFallback(
+                MOI.Utilities.Model{Float64}(),
+            ),
+            GLPK.Optimizer(),
+        )
+        MOI.Utilities.reset_optimizer(m)
+        m
+    else
+        GLPK.Optimizer()
+    end
+    MOI.set(model, MOI.Silent(), true)
     MOI.Utilities.loadfromstring!(
         model,
         """
@@ -20,8 +52,20 @@ function callback_simple_model()
     return model, x, y
 end
 
-function callback_knapsack_model()
-    model = GLPK.Optimizer()
+function _callback_knapsack_model(cache)
+    model = if cache
+        m = MOI.Utilities.CachingOptimizer(
+            MOI.Utilities.UniversalFallback(
+                MOI.Utilities.Model{Float64}(),
+            ),
+            GLPK.Optimizer(),
+        )
+        MOI.Utilities.reset_optimizer(m)
+        m
+    else
+        GLPK.Optimizer()
+    end
+    MOI.set(model, MOI.Silent(), true)
     N = 30
     x = MOI.add_variables(model, N)
     MOI.add_constraints(model, MOI.SingleVariable.(x), MOI.ZeroOne())
@@ -41,485 +85,489 @@ function callback_knapsack_model()
     return model, x, item_weights
 end
 
-@testset "All Callbacks" begin
-    @testset "LazyConstraintCallback" begin
-        @testset "LazyConstraint" begin
-            model, x, y = callback_simple_model()
-            lazy_called = false
-            MOI.set(
+function test_lazy_constraint(cache)
+    model, x, y = _callback_simple_model(cache)
+    lazy_called = false
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        (cb_data) -> begin
+            lazy_called = true
+            x_val = MOI.get(
                 model,
-                MOI.LazyConstraintCallback(),
-                (cb_data) -> begin
-                    lazy_called = true
-                    x_val = MOI.get(
-                        model,
-                        MOI.CallbackVariablePrimal(cb_data),
-                        x,
-                    )
-                    y_val = MOI.get(
-                        model,
-                        MOI.CallbackVariablePrimal(cb_data),
-                        y,
-                    )
-                    @test MOI.supports(model, MOI.LazyConstraint(cb_data))
-                    status =
-                        MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                    if [x_val, y_val] ≈ round.(Int, [x_val, y_val])
-                        atol = 1e-7
-                        @test status == MOI.CALLBACK_NODE_STATUS_INTEGER
-                    else
-                        @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                    end
-                    if y_val - x_val > 1 + 1e-6
-                        MOI.submit(
-                            model,
-                            MOI.LazyConstraint(cb_data),
-                            MOI.ScalarAffineFunction{Float64}(
-                                MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
-                                0.0,
-                            ),
-                            MOI.LessThan{Float64}(1.0),
-                        )
-                    elseif y_val + x_val > 3 + 1e-6
-                        MOI.submit(
-                            model,
-                            MOI.LazyConstraint(cb_data),
-                            MOI.ScalarAffineFunction{Float64}(
-                                MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
-                                0.0,
-                            ),
-                            MOI.LessThan{Float64}(3.0),
-                        )
-                    end
-                end,
+                MOI.CallbackVariablePrimal(cb_data),
+                x,
             )
-            @test MOI.supports(model, MOI.LazyConstraintCallback())
-            MOI.optimize!(model)
-            @test lazy_called
-            @test MOI.get(model, MOI.VariablePrimal(), x) == 1
-            @test MOI.get(model, MOI.VariablePrimal(), y) == 2
-        end
-        @testset "OptimizeInProgress" begin
-            model, x, y = callback_simple_model()
-            MOI.set(
+            y_val = MOI.get(
                 model,
-                MOI.LazyConstraintCallback(),
-                (cb_data) -> begin
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.VariablePrimal()),
-                        MOI.get(model, MOI.VariablePrimal(), x)
-                    )
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.ObjectiveValue()),
-                        MOI.get(model, MOI.ObjectiveValue())
-                    )
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.ObjectiveBound()),
-                        MOI.get(model, MOI.ObjectiveBound())
-                    )
-                end,
+                MOI.CallbackVariablePrimal(cb_data),
+                y,
             )
-            MOI.optimize!(model)
-        end
-        @testset "UserCut" begin
-            model, x, y = callback_simple_model()
-            MOI.set(
-                model,
-                MOI.LazyConstraintCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.UserCut(cb_data),
-                        MOI.ScalarAffineFunction(
-                            [MOI.ScalarAffineTerm(1.0, x)],
-                            0.0,
-                        ),
-                        MOI.LessThan(2.0),
-                    )
-                end,
-            )
-            @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.LazyConstraintCallback(),
-                    MOI.UserCut(model.callback_data),
-                ),
-                MOI.optimize!(model)
-            )
-        end
-        @testset "HeuristicSolution" begin
-            model, x, y = callback_simple_model()
-            MOI.set(
-                model,
-                MOI.LazyConstraintCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        [x, y],
-                        [1.0, 2.0],
-                    )
-                end,
-            )
-            @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.LazyConstraintCallback(),
-                    MOI.HeuristicSolution(model.callback_data),
-                ),
-                MOI.optimize!(model)
-            )
-        end
-    end
+            @test MOI.supports(model, MOI.LazyConstraint(cb_data))
+            status =
+                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            if [x_val, y_val] ≈ round.(Int, [x_val, y_val])
+                atol = 1e-7
+                @test status == MOI.CALLBACK_NODE_STATUS_INTEGER
+            else
+                @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+            end
+            if y_val - x_val > 1 + 1e-6
+                MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(1.0),
+                )
+            elseif y_val + x_val > 3 + 1e-6
+                MOI.submit(
+                    model,
+                    MOI.LazyConstraint(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(
+                        MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
+                        0.0,
+                    ),
+                    MOI.LessThan{Float64}(3.0),
+                )
+            end
+        end,
+    )
+    @test MOI.supports(model, MOI.LazyConstraintCallback())
+    MOI.optimize!(model)
+    @test lazy_called
+    @test MOI.get(model, MOI.VariablePrimal(), x) == 1
+    @test MOI.get(model, MOI.VariablePrimal(), y) == 2
+end
 
-    @testset "UserCutCallback" begin
-        @testset "UserCut" begin
-            model, x, item_weights = callback_knapsack_model()
-            user_cut_submitted = false
-            MOI.set(
-                model,
-                MOI.UserCutCallback(),
-                (cb_data) -> begin
-                    terms = MOI.ScalarAffineTerm{Float64}[]
-                    accumulated = 0.0
-                    for (i, xi) in enumerate(x)
-                        if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
-                            push!(terms, MOI.ScalarAffineTerm(1.0, xi))
-                            accumulated += item_weights[i]
-                        end
-                    end
-                    @test MOI.supports(model, MOI.UserCut(cb_data))
-                    status =
-                        MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                    @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                    if accumulated > 10.0
-                        MOI.submit(
-                            model,
-                            MOI.UserCut(cb_data),
-                            MOI.ScalarAffineFunction{Float64}(terms, 0.0),
-                            MOI.LessThan{Float64}(length(terms) - 1),
-                        )
-                        user_cut_submitted = true
-                    end
-                end,
-            )
-            @test MOI.supports(model, MOI.UserCutCallback())
-            MOI.optimize!(model)
-            @test user_cut_submitted
-        end
-        @testset "LazyConstraint" begin
-            model, x, item_weights = callback_knapsack_model()
-            MOI.set(
-                model,
-                MOI.UserCutCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.LazyConstraint(cb_data),
-                        MOI.ScalarAffineFunction(
-                            MOI.ScalarAffineTerm.(1.0, x),
-                            0.0,
-                        ),
-                        MOI.LessThan(5.0),
-                    )
-                end,
+function test_lazy_constraint_optimize_in_progress(cache)
+    model, x, y = _callback_simple_model(cache)
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        (cb_data) -> begin
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.VariablePrimal()),
+                MOI.get(model, MOI.VariablePrimal(), x)
             )
             @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.UserCutCallback(),
-                    MOI.LazyConstraint(model.callback_data),
-                ),
-                MOI.optimize!(model)
-            )
-        end
-        @testset "HeuristicSolution" begin
-            model, x, item_weights = callback_knapsack_model()
-            MOI.set(
-                model,
-                MOI.UserCutCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        x,
-                        fill(0.0, length(x)),
-                    )
-                end,
+                MOI.OptimizeInProgress(MOI.ObjectiveValue()),
+                MOI.get(model, MOI.ObjectiveValue())
             )
             @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.UserCutCallback(),
-                    MOI.HeuristicSolution(model.callback_data),
-                ),
-                MOI.optimize!(model)
+                MOI.OptimizeInProgress(MOI.ObjectiveBound()),
+                MOI.get(model, MOI.ObjectiveBound())
             )
-        end
-    end
+        end,
+    )
+    MOI.optimize!(model)
+end
 
-    @testset "HeuristicCallback" begin
-        @testset "HeuristicSolution" begin
-            model, x, item_weights = callback_knapsack_model()
-            solution_accepted = false
-            solution_rejected = false
-            MOI.set(
+function test_no_cache_LazyConstraint_UserCut()
+    model, x, y = _callback_simple_model(false)
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        (cb_data) -> begin
+            MOI.submit(
                 model,
-                MOI.HeuristicCallback(),
-                (cb_data) -> begin
-                    x_vals =
-                        MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
-                    @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
-                    if MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        x,
-                        floor.(x_vals),
-                    ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
-                        solution_accepted = true
-                    end
-                    if MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        [x[1]],
-                        [1.0],
-                    ) == MOI.HEURISTIC_SOLUTION_REJECTED
-                        solution_rejected = true
-                    end
-                    status =
-                        MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                    @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                end,
-            )
-            @test MOI.supports(model, MOI.HeuristicCallback())
-            MOI.optimize!(model)
-            @test solution_accepted
-            @test solution_rejected
-        end
-        @testset "LazyConstraint" begin
-            model, x, item_weights = callback_knapsack_model()
-            MOI.set(
-                model,
-                MOI.HeuristicCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.LazyConstraint(cb_data),
-                        MOI.ScalarAffineFunction(
-                            MOI.ScalarAffineTerm.(1.0, x),
-                            0.0,
-                        ),
-                        MOI.LessThan(5.0),
-                    )
-                end,
-            )
-            @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.HeuristicCallback(),
-                    MOI.LazyConstraint(model.callback_data),
+                MOI.UserCut(cb_data),
+                MOI.ScalarAffineFunction(
+                    [MOI.ScalarAffineTerm(1.0, x)],
+                    0.0,
                 ),
-                MOI.optimize!(model)
+                MOI.LessThan(2.0),
             )
-        end
-        @testset "UserCut" begin
-            model, x, item_weights = callback_knapsack_model()
-            MOI.set(
-                model,
-                MOI.HeuristicCallback(),
-                (cb_data) -> begin
-                    MOI.submit(
-                        model,
-                        MOI.UserCut(cb_data),
-                        MOI.ScalarAffineFunction(
-                            MOI.ScalarAffineTerm.(1.0, x),
-                            0.0,
-                        ),
-                        MOI.LessThan(5.0),
-                    )
-                end,
-            )
-            @test_throws(
-                MOI.InvalidCallbackUsage(
-                    MOI.HeuristicCallback(),
-                    MOI.UserCut(model.callback_data),
-                ),
-                MOI.optimize!(model)
-            )
-        end
-    end
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.LazyConstraintCallback(),
+            MOI.UserCut(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
 
-    @testset "GLPK.CallbackFunction" begin
-        @testset "OptimizeInProgress" begin
-            model, x, y = callback_simple_model()
-            MOI.set(
+function test_no_cache_LazyConstraint_HeuristicSolution()
+    model, x, y = _callback_simple_model(false)
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        (cb_data) -> begin
+            MOI.submit(
                 model,
-                GLPK.CallbackFunction(),
-                (cb_data) -> begin
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.VariablePrimal()),
-                        MOI.get(model, MOI.VariablePrimal(), x)
-                    )
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.ObjectiveValue()),
-                        MOI.get(model, MOI.ObjectiveValue())
-                    )
-                    @test_throws(
-                        MOI.OptimizeInProgress(MOI.ObjectiveBound()),
-                        MOI.get(model, MOI.ObjectiveBound())
-                    )
-                end,
+                MOI.HeuristicSolution(cb_data),
+                [x, y],
+                [1.0, 2.0],
             )
-            @test MOI.supports(model, GLPK.CallbackFunction())
-            MOI.optimize!(model)
-        end
-        @testset "LazyConstraint" begin
-            model, x, y = callback_simple_model()
-            cb_calls = Int32[]
-            function callback_function(cb_data)
-                reason = GLPK.glp_ios_reason(cb_data.tree)
-                push!(cb_calls, reason)
-                if reason != GLPK.GLP_IROWGEN
-                    return
-                end
-                x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
-                y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
-                status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                if [x_val, y_val] ≈ round.(Int, [x_val, y_val])
-                    atol = 1e-7
-                    @test status == MOI.CALLBACK_NODE_STATUS_INTEGER
-                else
-                    @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                end
-                if y_val - x_val > 1 + 1e-6
-                    MOI.submit(
-                        model,
-                        MOI.LazyConstraint(cb_data),
-                        MOI.ScalarAffineFunction{Float64}(
-                            MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
-                            0.0,
-                        ),
-                        MOI.LessThan{Float64}(1.0),
-                    )
-                elseif y_val + x_val > 3 + 1e-6
-                    MOI.submit(
-                        model,
-                        MOI.LazyConstraint(cb_data),
-                        MOI.ScalarAffineFunction{Float64}(
-                            MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
-                            0.0,
-                        ),
-                        MOI.LessThan{Float64}(3.0),
-                    )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.LazyConstraintCallback(),
+            MOI.HeuristicSolution(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_UserCut(cache)
+    model, x, item_weights = _callback_knapsack_model(cache)
+    user_cut_submitted = false
+    MOI.set(
+        model,
+        MOI.UserCutCallback(),
+        (cb_data) -> begin
+            terms = MOI.ScalarAffineTerm{Float64}[]
+            accumulated = 0.0
+            for (i, xi) in enumerate(x)
+                if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
+                    push!(terms, MOI.ScalarAffineTerm(1.0, xi))
+                    accumulated += item_weights[i]
                 end
             end
-            MOI.set(model, GLPK.CallbackFunction(), callback_function)
-            MOI.optimize!(model)
-            @test MOI.get(model, MOI.VariablePrimal(), x) == 1
-            @test MOI.get(model, MOI.VariablePrimal(), y) == 2
-            @test length(cb_calls) > 0
-            @test GLPK.GLP_ISELECT in cb_calls
-            @test GLPK.GLP_IPREPRO in cb_calls
-            @test GLPK.GLP_IROWGEN in cb_calls
-            @test GLPK.GLP_IBINGO in cb_calls
-            @test !(GLPK.GLP_IHEUR in cb_calls)
-        end
-        @testset "UserCut" begin
-            model, x, item_weights = callback_knapsack_model()
-            user_cut_submitted = false
-            cb_calls = Int32[]
-            MOI.set(
-                model,
-                GLPK.CallbackFunction(),
-                (cb_data) -> begin
-                    reason = GLPK.glp_ios_reason(cb_data.tree)
-                    push!(cb_calls, reason)
-                    if reason != GLPK.GLP_ICUTGEN
-                        status =
-                            MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                        @test status !== nothing
-                        return
-                    end
-                    terms = MOI.ScalarAffineTerm{Float64}[]
-                    accumulated = 0.0
-                    for (i, xi) in enumerate(x)
-                        if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
-                            push!(terms, MOI.ScalarAffineTerm(1.0, xi))
-                            accumulated += item_weights[i]
-                        end
-                    end
-                    if accumulated > 10.0
-                        MOI.submit(
-                            model,
-                            MOI.UserCut(cb_data),
-                            MOI.ScalarAffineFunction{Float64}(terms, 0.0),
-                            MOI.LessThan{Float64}(length(terms) - 1),
-                        )
-                        user_cut_submitted = true
-                    end
-                    status =
-                        MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                    @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                end,
-            )
-            MOI.optimize!(model)
-            @test user_cut_submitted
-            @test GLPK.GLP_ICUTGEN in cb_calls
-        end
-        @testset "HeuristicSolution" begin
-            model, x, item_weights = callback_knapsack_model()
-            solution_accepted = false
-            solution_rejected = false
-            cb_calls = Int32[]
-            MOI.set(
-                model,
-                GLPK.CallbackFunction(),
-                (cb_data) -> begin
-                    reason = GLPK.glp_ios_reason(cb_data.tree)
-                    push!(cb_calls, reason)
-                    if reason != GLPK.GLP_IHEUR
-                        return
-                    end
-                    x_vals =
-                        MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
-                    if MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        x,
-                        floor.(x_vals),
-                    ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
-                        solution_accepted = true
-                    end
-                    if MOI.submit(
-                        model,
-                        MOI.HeuristicSolution(cb_data),
-                        [x[1]],
-                        [1.0],
-                    ) == MOI.HEURISTIC_SOLUTION_REJECTED
-                        solution_rejected = true
-                    end
-                    status =
-                        MOI.get(model, MOI.CallbackNodeStatus(cb_data))
-                    @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
-                end,
-            )
-            MOI.optimize!(model)
-            @test solution_accepted
-            @test solution_rejected
-            @test GLPK.GLP_IHEUR in cb_calls
-        end
-    end
-
-    @testset "broadcasting" begin
-        model, x, _ = callback_knapsack_model()
-        f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
-        solutions = Vector{Float64}[]
-        MOI.set(
-            model,
-            GLPK.CallbackFunction(),
-            (cb_data) -> begin
-                if GLPK.glp_ios_reason(cb_data.tree) == GLPK.GLP_IHEUR
-                    push!(solutions, f.(cb_data, x))
-                end
-            end,
-        )
-        MOI.optimize!(model)
-        @test length(solutions) > 0
-        @test length(solutions[1]) == length(x)
-    end
+            @test MOI.supports(model, MOI.UserCut(cb_data))
+            status =
+                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+            if accumulated > 10.0
+                MOI.submit(
+                    model,
+                    MOI.UserCut(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(terms, 0.0),
+                    MOI.LessThan{Float64}(length(terms) - 1),
+                )
+                user_cut_submitted = true
+            end
+        end,
+    )
+    @test MOI.supports(model, MOI.UserCutCallback())
+    MOI.optimize!(model)
+    @test user_cut_submitted
 end
+
+function test_no_cache_UserCut_LazyConstraint()
+    model, x, item_weights = _callback_knapsack_model(false)
+    MOI.set(
+        model,
+        MOI.UserCutCallback(),
+        (cb_data) -> begin
+            MOI.submit(
+                model,
+                MOI.LazyConstraint(cb_data),
+                MOI.ScalarAffineFunction(
+                    MOI.ScalarAffineTerm.(1.0, x),
+                    0.0,
+                ),
+                MOI.LessThan(5.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.UserCutCallback(),
+            MOI.LazyConstraint(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_no_cache_UserCut_HeuristicSolution()
+    model, x, item_weights = _callback_knapsack_model(false)
+    MOI.set(
+        model,
+        MOI.UserCutCallback(),
+        (cb_data) -> begin
+            MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                x,
+                fill(0.0, length(x)),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.UserCutCallback(),
+            MOI.HeuristicSolution(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_Heuristic(cache)
+    model, x, item_weights = _callback_knapsack_model(cache)
+    solution_accepted = false
+    solution_rejected = false
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        (cb_data) -> begin
+            x_vals =
+                MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+            @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
+            if MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                x,
+                floor.(x_vals),
+            ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
+                solution_accepted = true
+            end
+            if MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                [x[1]],
+                [1.0],
+            ) == MOI.HEURISTIC_SOLUTION_REJECTED
+                solution_rejected = true
+            end
+            status =
+                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+        end,
+    )
+    @test MOI.supports(model, MOI.HeuristicCallback())
+    MOI.optimize!(model)
+    @test solution_accepted
+    @test solution_rejected
+end
+
+function test_no_cache_Heuristic_LazyConstraint()
+    model, x, item_weights = _callback_knapsack_model(false)
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        (cb_data) -> begin
+            MOI.submit(
+                model,
+                MOI.LazyConstraint(cb_data),
+                MOI.ScalarAffineFunction(
+                    MOI.ScalarAffineTerm.(1.0, x),
+                    0.0,
+                ),
+                MOI.LessThan(5.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.HeuristicCallback(),
+            MOI.LazyConstraint(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_no_cache_Heuristic_UserCut()
+    model, x, item_weights = _callback_knapsack_model(false)
+    MOI.set(
+        model,
+        MOI.HeuristicCallback(),
+        (cb_data) -> begin
+            MOI.submit(
+                model,
+                MOI.UserCut(cb_data),
+                MOI.ScalarAffineFunction(
+                    MOI.ScalarAffineTerm.(1.0, x),
+                    0.0,
+                ),
+                MOI.LessThan(5.0),
+            )
+        end,
+    )
+    @test_throws(
+        MOI.InvalidCallbackUsage(
+            MOI.HeuristicCallback(),
+            MOI.UserCut(model.callback_data),
+        ),
+        MOI.optimize!(model)
+    )
+end
+
+function test_CallbackFunction_OptimizeInProgress(cache)
+    model, x, y = _callback_simple_model(cache)
+    MOI.set(
+        model,
+        GLPK.CallbackFunction(),
+        (cb_data) -> begin
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.VariablePrimal()),
+                MOI.get(model, MOI.VariablePrimal(), x)
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveValue()),
+                MOI.get(model, MOI.ObjectiveValue())
+            )
+            @test_throws(
+                MOI.OptimizeInProgress(MOI.ObjectiveBound()),
+                MOI.get(model, MOI.ObjectiveBound())
+            )
+        end,
+    )
+    @test MOI.supports(model, GLPK.CallbackFunction())
+    MOI.optimize!(model)
+end
+
+function test_CallbackFunction_LazyConstraint(cache)
+    model, x, y = _callback_simple_model(cache)
+    cb_calls = Int32[]
+    function callback_function(cb_data)
+        reason = GLPK.glp_ios_reason(cb_data.tree)
+        push!(cb_calls, reason)
+        if reason != GLPK.GLP_IROWGEN
+            return
+        end
+        x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+        y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
+        status = MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+        if [x_val, y_val] ≈ round.(Int, [x_val, y_val])
+            atol = 1e-7
+            @test status == MOI.CALLBACK_NODE_STATUS_INTEGER
+        else
+            @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+        end
+        if y_val - x_val > 1 + 1e-6
+            MOI.submit(
+                model,
+                MOI.LazyConstraint(cb_data),
+                MOI.ScalarAffineFunction{Float64}(
+                    MOI.ScalarAffineTerm.([-1.0, 1.0], [x, y]),
+                    0.0,
+                ),
+                MOI.LessThan{Float64}(1.0),
+            )
+        elseif y_val + x_val > 3 + 1e-6
+            MOI.submit(
+                model,
+                MOI.LazyConstraint(cb_data),
+                MOI.ScalarAffineFunction{Float64}(
+                    MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
+                    0.0,
+                ),
+                MOI.LessThan{Float64}(3.0),
+            )
+        end
+    end
+    MOI.set(model, GLPK.CallbackFunction(), callback_function)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) == 1
+    @test MOI.get(model, MOI.VariablePrimal(), y) == 2
+    @test length(cb_calls) > 0
+    @test GLPK.GLP_ISELECT in cb_calls
+    @test GLPK.GLP_IPREPRO in cb_calls
+    @test GLPK.GLP_IROWGEN in cb_calls
+    @test GLPK.GLP_IBINGO in cb_calls
+    @test !(GLPK.GLP_IHEUR in cb_calls)
+end
+
+function test_CallbackFunction_UserCut(cache)
+    model, x, item_weights = _callback_knapsack_model(cache)
+    user_cut_submitted = false
+    cb_calls = Int32[]
+    MOI.set(
+        model,
+        GLPK.CallbackFunction(),
+        (cb_data) -> begin
+            reason = GLPK.glp_ios_reason(cb_data.tree)
+            push!(cb_calls, reason)
+            if reason != GLPK.GLP_ICUTGEN
+                status =
+                    MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+                @test status !== nothing
+                return
+            end
+            terms = MOI.ScalarAffineTerm{Float64}[]
+            accumulated = 0.0
+            for (i, xi) in enumerate(x)
+                if MOI.get(model, MOI.CallbackVariablePrimal(cb_data), xi) > 0.0
+                    push!(terms, MOI.ScalarAffineTerm(1.0, xi))
+                    accumulated += item_weights[i]
+                end
+            end
+            if accumulated > 10.0
+                MOI.submit(
+                    model,
+                    MOI.UserCut(cb_data),
+                    MOI.ScalarAffineFunction{Float64}(terms, 0.0),
+                    MOI.LessThan{Float64}(length(terms) - 1),
+                )
+                user_cut_submitted = true
+            end
+            status =
+                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+        end,
+    )
+    MOI.optimize!(model)
+    @test user_cut_submitted
+    @test GLPK.GLP_ICUTGEN in cb_calls
+end
+
+function test_CallbackFunction_HeuristicSolution(cache)
+    model, x, item_weights = _callback_knapsack_model(cache)
+    solution_accepted = false
+    solution_rejected = false
+    cb_calls = Int32[]
+    MOI.set(
+        model,
+        GLPK.CallbackFunction(),
+        (cb_data) -> begin
+            reason = GLPK.glp_ios_reason(cb_data.tree)
+            push!(cb_calls, reason)
+            if reason != GLPK.GLP_IHEUR
+                return
+            end
+            x_vals =
+                MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+            if MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                x,
+                floor.(x_vals),
+            ) == MOI.HEURISTIC_SOLUTION_ACCEPTED
+                solution_accepted = true
+            end
+            if MOI.submit(
+                model,
+                MOI.HeuristicSolution(cb_data),
+                [x[1]],
+                [1.0],
+            ) == MOI.HEURISTIC_SOLUTION_REJECTED
+                solution_rejected = true
+            end
+            status =
+                MOI.get(model, MOI.CallbackNodeStatus(cb_data))
+            @test status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+        end,
+    )
+    MOI.optimize!(model)
+    @test solution_accepted
+    @test solution_rejected
+    @test GLPK.GLP_IHEUR in cb_calls
+end
+
+function test_broadcasting(cache)
+    model, x, _ = _callback_knapsack_model(cache)
+    f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+    solutions = Vector{Float64}[]
+    MOI.set(
+        model,
+        GLPK.CallbackFunction(),
+        (cb_data) -> begin
+            if GLPK.glp_ios_reason(cb_data.tree) == GLPK.GLP_IHEUR
+                push!(solutions, f.(cb_data, x))
+            end
+        end,
+    )
+    MOI.optimize!(model)
+    @test length(solutions) > 0
+    @test length(solutions[1]) == length(x)
+end
+
+end
+
+TestCallbacks.runtests()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -87,6 +87,21 @@ end
         CONFIG,
         ["int2", "indicator1", "indicator2", "indicator3", "indicator4"],
     )
+    @testset "Cached solver for `copy_to`" begin
+        MOIT.intlineartest(
+            MOI.Bridges.full_bridge_optimizer(
+                MOI.Utilities.CachingOptimizer(
+                    MOI.Utilities.UniversalFallback(
+                        MOI.Utilities.Model{Float64}(),
+                    ),
+                    GLPK.Optimizer(),
+                ),
+                Float64,
+            ),
+            CONFIG,
+            ["int2", "indicator1", "indicator2", "indicator3", "indicator4"],
+        )
+    end
 end
 
 @testset "ModelLike tests" begin
@@ -791,4 +806,18 @@ end
     model = GLPK.Optimizer()
     MOI.set(model, MOI.TimeLimitSec(), 1.2345)
     @test MOI.get(model, MOI.TimeLimitSec()) == 1.235
+end
+
+
+@testset "empty problem" begin
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(
+            MOI.Utilities.Model{Float64}(),
+        ),
+        GLPK.Optimizer(),
+    )
+    MOI.Utilities.reset_optimizer(model)
+    MOI.add_variable(model)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -808,12 +808,9 @@ end
     @test MOI.get(model, MOI.TimeLimitSec()) == 1.235
 end
 
-
 @testset "empty problem" begin
     model = MOI.Utilities.CachingOptimizer(
-        MOI.Utilities.UniversalFallback(
-            MOI.Utilities.Model{Float64}(),
-        ),
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
         GLPK.Optimizer(),
     )
     MOI.Utilities.reset_optimizer(model)


### PR DESCRIPTION
This fixes a couple of other bugs in `MOI.copy_to`. We weren't setting integrality, and GLPK doesn't like empty models.

This PR also improves the testing. Lesson learned: if JuMP rolls out direct copies, we need the solvers to much more thoroughly test their `copy_to` functions via a CachingOptimizer.