### PR TITLE
Improve performance of MOI.copy_to

### DIFF
--- a/src/MOI_wrapper/MOI_copy.jl
+++ b/src/MOI_wrapper/MOI_copy.jl
@@ -92,34 +92,28 @@ function _add_set_data(cache, i, s::MOI.Interval{Float64})
     return
 end
 
-function _extract_bound_data(src, map, cache, s::Type{S}) where {S}
+_add_set_data(cache, i, ::MOI.Integer) = (cache.types[i] = _INTEGER)
+
+_add_set_data(cache, i, ::MOI.ZeroOne) = (cache.types[i] = _BINARY)
+
+function _extract_variable_data(src, map, cache, ::Type{S}) where {S}
+    ci_map = map.con_map[MOI.VariableIndex, S]
     for ci in MOI.get(src, MOI.ListOfConstraintIndices{MOI.VariableIndex,S}())
         f = MOI.get(src, MOI.ConstraintFunction(), ci)
         s = MOI.get(src, MOI.ConstraintSet(), ci)
         column = map[f].value
         _add_set_data(cache, column, s)
-        map[ci] = MOI.ConstraintIndex{MOI.VariableIndex,S}(column)
-    end
-    return
-end
-
-function _extract_type_data(src, map, cache, ::Type{S}) where {S}
-    for ci in MOI.get(src, MOI.ListOfConstraintIndices{MOI.VariableIndex,S}())
-        f = MOI.get(src, MOI.ConstraintFunction(), ci)
-        column = map[f].value
-        cache.types[column] = S == MOI.Integer ? _INTEGER : _BINARY
-        map[ci] = MOI.ConstraintIndex{MOI.VariableIndex,S}(column)
+        ci_map[ci] = MOI.ConstraintIndex{MOI.VariableIndex,S}(column)
     end
     return
 end
 
 function _extract_row_data(src, map, cache, ::Type{S}) where {S}
+    F = MOI.ScalarAffineFunction{Float64}
+    ci_map = map.con_map[F, S]
     nnz = length(cache.I)
     row = nnz == 0 ? 1 : cache.I[end] + 1
-    for ci in MOI.get(
-        src,
-        MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64},S}(),
-    )::Vector{MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},S}}
+    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
         f = MOI.get(src, MOI.ConstraintFunction(), ci)
         if !MOI.Utilities.is_canonical(f)
             f = MOI.Utilities.canonical(f)
@@ -136,7 +130,7 @@ function _extract_row_data(src, map, cache, ::Type{S}) where {S}
             cache.J[nnz] = Cint(map[term.variable].value::Int64)
             cache.V[nnz] = term.coefficient
         end
-        map[ci] = MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},S}(row)
+        ci_map[ci] = MOI.ConstraintIndex{F,S}(row)
         row += 1
     end
     return
@@ -160,7 +154,7 @@ function _add_all_variables(model::Optimizer, cache::_OptimizerCache)
     N = length(cache.cl)
     glp_add_cols(model, N)
     sizehint!(model.variable_info, N)
-    for i in 1:N
+    @inbounds for i in 1:N
         bound = _get_moi_bound_type(cache.cl[i], cache.cu[i], cache.bounds[i])
         CleverDicts.add_item(
             model.variable_info,
@@ -193,7 +187,8 @@ function _add_all_constraints(dest::Optimizer, cache::_OptimizerCache)
         offset(cache.V),
     )
     sizehint!(dest.affine_constraint_info, N)
-    for (i, l, u) in zip(1:N, cache.rl, cache.ru)
+    @inbounds for i in 1:N
+        l, u = cache.rl[i], cache.ru[i]
         if l == -Inf
             glp_set_row_bnds(dest, i, GLP_UP, -GLP_DBL_MAX, u)
             CleverDicts.add_item(
@@ -226,13 +221,13 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
     cache = _OptimizerCache(length(variables))
     # Extract the problem data
     #   Variable bounds:
-    _extract_bound_data(src, map, cache, MOI.GreaterThan{Float64})
-    _extract_bound_data(src, map, cache, MOI.LessThan{Float64})
-    _extract_bound_data(src, map, cache, MOI.EqualTo{Float64})
-    _extract_bound_data(src, map, cache, MOI.Interval{Float64})
+    _extract_variable_data(src, map, cache, MOI.GreaterThan{Float64})
+    _extract_variable_data(src, map, cache, MOI.LessThan{Float64})
+    _extract_variable_data(src, map, cache, MOI.EqualTo{Float64})
+    _extract_variable_data(src, map, cache, MOI.Interval{Float64})
     #   Variable types:
-    _extract_type_data(src, map, cache, MOI.Integer)
-    _extract_type_data(src, map, cache, MOI.ZeroOne)
+    _extract_variable_data(src, map, cache, MOI.Integer)
+    _extract_variable_data(src, map, cache, MOI.ZeroOne)
     #   Affine constraints:
     _extract_row_data(src, map, cache, MOI.GreaterThan{Float64})
     _extract_row_data(src, map, cache, MOI.LessThan{Float64})


### PR DESCRIPTION
Part of https://github.com/jump-dev/JuMP.jl/issues/2817

If we include https://github.com/jump-dev/MathOptInterface.jl/pull/1704

Script
```Julia
using MathOptInterface
const MOI = MathOptInterface
using GLPK

function create_model(I, T = 10000)
    model = MOI.Utilities.Model{Float64}()
    v = MOI.VariableIndex[]
    for _ in 1:I
        x = MOI.add_variables(model, T)
        MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
        MOI.add_constraint.(model, x, MOI.LessThan(100.0))
        for t in 2:T
            f = MOI.ScalarAffineFunction(
                MOI.ScalarAffineTerm.([1.0, -1.0], [x[t], x[t-1]]),
                0.0,
            )
            MOI.add_constraint(model, f, MOI.GreaterThan(-10.0))
            MOI.add_constraint(model, f, MOI.LessThan(10.0))
        end
        append!(v, x)
    end
    g = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, v), 0.0)
    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
    MOI.set(model, MOI.ObjectiveFunction{typeof(g)}(), g)
    dest = GLPK.Optimizer()
    MOI.copy_to(dest, model)
    return dest
end
```

Before
```Julia
julia> @benchmark create_model(100, 1000)
BenchmarkTools.Trial: 11 samples with 1 evaluation.
 Range (min … max):  348.692 ms … 690.298 ms  ┊ GC (min … max): 23.52% … 55.39%
 Time  (median):     468.977 ms               ┊ GC (median):    34.47%
 Time  (mean ± σ):   510.078 ms ± 141.469 ms  ┊ GC (mean ± σ):  44.43% ± 15.48%

  ▁  ▁ █   ▁           ▁                           █    ▁  ▁  ▁  
  █▁▁█▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁█▁▁█ ▁
  349 ms           Histogram: frequency by time          690 ms <

 Memory estimate: 384.43 MiB, allocs estimate: 2898897.
```

After
```Julia
julia> @benchmark create_model(100, 1000)
BenchmarkTools.Trial: 20 samples with 1 evaluation.
 Range (min … max):  184.094 ms … 390.970 ms  ┊ GC (min … max): 12.39% … 19.73%
 Time  (median):     240.240 ms               ┊ GC (median):    24.33%
 Time  (mean ± σ):   253.573 ms ±  43.221 ms  ┊ GC (mean ± σ):  24.21% ±  5.05%

                ▃██       ▃  ▃                                   
  ▇▁▁▁▁▁▁▁▁▁▇▁▇▇███▁▁▇▇▁▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇ ▁
  184 ms           Histogram: frequency by time          391 ms <

 Memory estimate: 152.62 MiB, allocs estimate: 1299738.
```