### PR TITLE
MOI.SUPERBASIC -> MOI.SUPER_BASIC

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -2209,6 +2209,6 @@ function MOI.get(
         return MOI.NONBASIC
     else
         @assert vbasis == GLP_NS
-        return MOI.SUPERBASIC
+        return MOI.SUPER_BASIC
     end
 end


### PR DESCRIPTION
`MOI.SUPERBASIC` is not defined. Looks like it's `SUPER_BASIC` (see https://github.com/jump-dev/MathOptInterface.jl/blob/d281d6394ff5c3b29b5da1cb8a05acb80ed1d637/src/attributes.jl#L1308 MOI v1.1.0).