### PR TITLE
Fix VariableBasisStatus and add test

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -2199,16 +2199,16 @@ function MOI.get(
     _throw_if_optimize_in_progress(model, attr)
     col = column(model, x)
     vbasis = glp_get_col_stat(model, col)
-    if vbasis == GLP_BS
+    if vbasis == GLP_BS  # basic variable
         return MOI.BASIC
-    elseif vbasis == GLP_NL
+    elseif vbasis == GLP_NL  # non-basic variable having active lower bound
         return MOI.NONBASIC_AT_LOWER
-    elseif vbasis == GLP_NU
+    elseif vbasis == GLP_NU  # non-basic variable having active upper bound
         return MOI.NONBASIC_AT_UPPER
-    elseif vbasis == GLP_NF
-        return MOI.NONBASIC
-    else
-        @assert vbasis == GLP_NS
+    elseif vbasis == GLP_NF  # non-basic free variable
         return MOI.SUPER_BASIC
+    else
+        @assert vbasis == GLP_NS  # nonbasic fixed variable
+        return MOI.NONBASIC
     end
 end


### PR DESCRIPTION
I think we had `GLP_NS` and `GLP_NF` around the wrong way. Raised by @guimarqu in https://github.com/jump-dev/GLPK.jl/pull/213

Here's the paragraph from the manual: http://most.ccib.rutgers.edu/glpk.pdf

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/8177701/158459424-2c9a67a8-b12e-4273-b225-68e287fb3e40.png">

`GLP_NF` is a non-basic free variable which corresponds to our super-basic.

I also added a test which returns at least one of each status, but it's probably quite fragile between GLPK versions because the model has lots of weirdness.