### PR TITLE
Add MOI.modify for multiple changes at once

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -586,7 +586,7 @@ function test_multiple_modifications()
     fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
     @test MOI.coefficient.(fc1.terms) == [4.0, 1.0, 1.0]
     fc2 = MOI.get(model, MOI.ConstraintFunction(), ci2)
-    @test MOI.coefficient.(fc2.terms) == [2.0, 1.0, 0.5]
+    @test MOI.coefficient.(fc2.terms) == [0.5, 1.0, 2.0]
 end
 
 end  # module

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -544,6 +544,51 @@ function test_variable_basis_status()
     return
 end
 
+function test_multiple_modifications()
+    model = GLPK.Optimizer()
+
+    x = MOI.add_variables(model, 3)
+
+    saf = MOI.ScalarAffineFunction(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(1.0, x[2]),
+            MOI.ScalarAffineTerm(1.0, x[3]),
+        ],
+        0.0,
+    )
+    ci1 = MOI.add_constraint(model, saf, MOI.LessThan(1.0))
+    ci2 = MOI.add_constraint(model, saf, MOI.LessThan(2.0))
+
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        saf,
+    )
+
+    fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
+    @test MOI.coefficient.(fc1.terms) == [1.0, 1.0, 1.0]
+    fc2 = MOI.get(model, MOI.ConstraintFunction(), ci2)
+    @test MOI.coefficient.(fc2.terms) == [1.0, 1.0, 1.0]
+    obj = MOI.get(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+    )
+    @test MOI.coefficient.(obj.terms) == [1.0, 1.0, 1.0]
+
+    changes_cis = [
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(1), 4.0)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(1), 0.5)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(3), 2.0)
+    ]
+    MOI.modify(model, [ci1, ci2, ci2], changes_cis)
+
+    fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
+    @test MOI.coefficient.(fc1.terms) == [4.0, 1.0, 1.0]
+    fc2 = MOI.get(model, MOI.ConstraintFunction(), ci2)
+    @test MOI.coefficient.(fc2.terms) == [2.0, 1.0, 0.5]
+end
+
 end  # module
 
 TestMOIWrapper.runtests()


### PR DESCRIPTION
This is a follow-up from https://github.com/jump-dev/MathOptInterface.jl/pull/1800
It significantly improved the performance of updates. Using the same code from the PR above:
```julia
julia> @btime update_parameters_multiple_times_with_single_change(num_variables, num_solves)
  9.115 s (255872 allocations: 2.81 GiB)

julia> @btime update_parameters_multiple_times_with_multiple_changes(num_variables, num_solves)
  2.522 ms (5800 allocations: 2.33 MiB)
```
Modifying multiple objective coefficients isn't available in GLPK