### PR TITLE
Improve stacktrace of errors thrown from within a callback

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -232,7 +232,7 @@ function _internal_callback(tree::Ptr{Cvoid}, info::Ptr{Cvoid})
         cb_data.callback_function(cb_data)
     catch ex
         glp_ios_terminate(tree)
-        cb_data.exception = ex
+        cb_data.exception = CapturedException(ex, catch_backtrace())
     end
     return Cint(0)
 end

--- a/test/MOI_callbacks.jl
+++ b/test/MOI_callbacks.jl
@@ -577,7 +577,7 @@ function test_no_cache_InterruptException()
     return
 end
 
-function test_issue_232()
+function test_no_cache_issue_232()
     model = GLPK.Optimizer()
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.ZeroOne())


### PR DESCRIPTION
Closes #232

Now gives:
```Julia
julia> using GLPK; import MathOptInterface as MOI

julia> model = GLPK.Optimizer()
A GLPK model

julia> x = MOI.add_variable(model)
MOI.VariableIndex(1)

julia> MOI.add_constraint(model, x, MOI.ZeroOne())
MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}(1)

julia> my_callback(args...) = error("FooBar")
my_callback (generic function with 1 method)

julia> MOI.set(model, GLPK.CallbackFunction(), my_callback)

julia> MOI.optimize!(model)
ERROR: FooBar
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] my_callback(args::GLPK.CallbackData)
    @ Main ./REPL[5]:1
  [3] (::GLPK.var"#17#18"{GLPK.Optimizer, typeof(my_callback)})(cb_data::GLPK.CallbackData)
    @ GLPK ~/.julia/dev/GLPK/src/MOI_wrapper/MOI_callbacks.jl:31
  [4] _internal_callback(tree::Ptr{Nothing}, info::Ptr{Nothing})
    @ GLPK ~/.julia/dev/GLPK/src/MOI_wrapper/MOI_wrapper.jl:232
  [5] glp_intopt
    @ ~/.julia/dev/GLPK/src/gen/libglpk_api.jl:342 [inlined]
  [6] _solve_mip_problem(model::GLPK.Optimizer)
    @ GLPK ~/.julia/dev/GLPK/src/MOI_wrapper/MOI_wrapper.jl:1399
  [7] optimize!(model::GLPK.Optimizer)
    @ GLPK ~/.julia/dev/GLPK/src/MOI_wrapper/MOI_wrapper.jl:1448
```